### PR TITLE
warnCount needs to be a string

### DIFF
--- a/safe_power_monitor.py
+++ b/safe_power_monitor.py
@@ -108,7 +108,7 @@ class BatteryWatcher(GpioWatcher):
       self.warnCount += 1
       self.playerFlag = 1
       self.previousWarn = time.time()
-      log(23, "Low battery warning number " + warnCount + " was displayed.")
+      log(23, "Low battery warning number " + str(warnCount) + " was displayed.")
       os.system(videoPlayer + " " + lowalertVideo + " --alpha " + videoAlpha + ";")
       playerFlag = 0
 


### PR DESCRIPTION
TypeError: cannot concatenate 'str' and 'int' objects